### PR TITLE
#9 Moved image export

### DIFF
--- a/Editor/PrefabLightmapTool.cs
+++ b/Editor/PrefabLightmapTool.cs
@@ -596,26 +596,9 @@ public class PrefabLightmapTool : EditorWindow
 
                     renderData.LightmapOffsetScale = renderer.lightmapScaleOffset;
 
-                    Texture2D lightmap = PrefabLightmapTool.CopyLightmap(
-                        LightmapSettings.lightmaps[renderer.lightmapIndex].lightmapColor,
-                        exportRoot,
-                        objectName,
-                        lightmapName,
-                        TextureImporterType.Lightmap);
-
-                    Texture2D lightmapDir = PrefabLightmapTool.CopyLightmap(
-                        LightmapSettings.lightmaps[renderer.lightmapIndex].lightmapDir,
-                        exportRoot,
-                        objectName,
-                        lightmapName,
-                        TextureImporterType.DirectionalLightmap);
-
-                    Texture2D shadowMask = PrefabLightmapTool.CopyLightmap(
-                        LightmapSettings.lightmaps[renderer.lightmapIndex].shadowMask,
-                        exportRoot,
-                        objectName,
-                        lightmapName,
-                        TextureImporterType.Shadowmask);
+                    Texture2D lightmap = LightmapSettings.lightmaps[renderer.lightmapIndex].lightmapColor;
+                    Texture2D lightmapDir = LightmapSettings.lightmaps[renderer.lightmapIndex].lightmapDir;
+                    Texture2D shadowMask = LightmapSettings.lightmaps[renderer.lightmapIndex].shadowMask;
 
                     renderData.LightmapIndex = lightmapList.IndexOf(lightmap);
 
@@ -650,6 +633,42 @@ public class PrefabLightmapTool : EditorWindow
         data.ShadowMasks = shadowMaskList.ToArray();
         data.LightData = lightsDataList.ToArray();
         data.RendererData = renderDataList.ToArray();
+
+        for (int i = 0; i < data.Lightmaps.Length; i++)        
+        {
+            Texture2D copied = PrefabLightmapTool.CopyLightmap(
+                data.Lightmaps[i],
+                exportRoot,
+                objectName,
+                lightmapName,
+                TextureImporterType.Lightmap);
+
+            data.Lightmaps[i] = copied;
+        }
+
+        for (int i = 0; i < data.DirectionalLightmaps.Length; i++)
+        {
+            Texture2D copied = PrefabLightmapTool.CopyLightmap(
+                data.DirectionalLightmaps[i],
+                exportRoot,
+                objectName,
+                lightmapName,
+                TextureImporterType.DirectionalLightmap);
+
+            data.DirectionalLightmaps[i] = copied;
+        }
+
+        for (int i = 0; i < data.ShadowMasks.Length; i++)
+        {
+            Texture2D copied = PrefabLightmapTool.CopyLightmap(
+                data.ShadowMasks[i],
+                exportRoot,
+                objectName,
+                lightmapName,
+                TextureImporterType.Shadowmask);
+
+            data.ShadowMasks[i] = copied;
+        }
 
         return data;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The image collection and export was done at the top of the data gathering function but when the images were copied they were no longer references to the lightdata images and thus failed comparison checks.   Moved the export to the end of the data gathering function after all the images had been checked for duplication.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue, asset and/or documentation issues here: -->
#9 Missing Textures When Lightmaps are Packed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed reproduction steps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the game logic.
    - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
