### PR TITLE
#20 Fixed CreateGUI/OnFocus race condition

### DIFF
--- a/Editor/PrefabLightmapTool.cs
+++ b/Editor/PrefabLightmapTool.cs
@@ -44,7 +44,11 @@ public class PrefabLightmapTool : EditorWindow
     /// <summary>
     /// Internal value for determining if the bake was started as a result of this tool
     /// </summary>
-    protected bool startedBaking;
+    protected bool StartedBaking;
+    /// <summary>
+    /// If the GUI has been loaded by CreateGUI
+    /// </summary>
+    protected bool UILoaded;
 
     /// <summary>
     /// Export path text field
@@ -156,10 +160,12 @@ public class PrefabLightmapTool : EditorWindow
         this.ButtonBake.clicked += this.ButtonBakeClicked;
 
         this.UpdateListView();
+
+        this.UILoaded = true;
     }
     public void OnFocus()
     {
-        this.UpdateListView();
+        if (this.UILoaded) this.UpdateListView();
     }
 
     /// <summary>
@@ -223,7 +229,7 @@ public class PrefabLightmapTool : EditorWindow
             return;
         }
 
-        this.startedBaking = true;
+        this.StartedBaking = true;
 
         Lightmapping.bakeCompleted += this.UpdatePrefabs;
         Lightmapping.BakeAsync();
@@ -310,7 +316,7 @@ public class PrefabLightmapTool : EditorWindow
     /// </summary>
     protected void UpdateListView()
     {
-        List<PrefabLightmapDataItem> items = this.FindPrefabLightmapItems();        
+        List<PrefabLightmapDataItem> items = this.FindPrefabLightmapItems();
 
         if (items.Count > 0)
             this.ToggleAll.SetEnabled(true);
@@ -373,7 +379,7 @@ public class PrefabLightmapTool : EditorWindow
     /// </summary>
     protected void UpdatePrefabs()
     {
-        if (this.startedBaking == false)
+        if (this.StartedBaking == false)
             return;
 
         int counter = 0;
@@ -452,7 +458,7 @@ public class PrefabLightmapTool : EditorWindow
             }
         }
 
-        this.startedBaking = false;
+        this.StartedBaking = false;
     }
 
     /// <summary>
@@ -632,7 +638,7 @@ public class PrefabLightmapTool : EditorWindow
         data.LightData = lightsDataList.ToArray();
         data.RendererData = renderDataList.ToArray();
 
-        for (int i = 0; i < data.Lightmaps.Length; i++)        
+        for (int i = 0; i < data.Lightmaps.Length; i++)
         {
             Texture2D copied = PrefabLightmapTool.CopyLightmap(
                 data.Lightmaps[i],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Put in a bool that is checked by OnFocus that is set by CreateUI to denote that the UI has loaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue, asset and/or documentation issues here: -->
#20 Null Exception When Opening Unity

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Eliminates the null exception on startup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed the reproduction steps

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the game logic.
    - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
