### PR TITLE
#30 Added isReadable flag to exported textures

### DIFF
--- a/Editor/PrefabLightmapTool.cs
+++ b/Editor/PrefabLightmapTool.cs
@@ -98,7 +98,6 @@ public class PrefabLightmapTool : EditorWindow
         wnd.minSize = new Vector2(330, 300);
     }
 
-
     public void CreateGUI()
     {
         bool found = false;
@@ -165,7 +164,7 @@ public class PrefabLightmapTool : EditorWindow
     }
     public void OnFocus()
     {
-        if (this.UILoaded) this.UpdateListView();
+        this.UpdateListView();
     }
 
     /// <summary>
@@ -316,6 +315,9 @@ public class PrefabLightmapTool : EditorWindow
     /// </summary>
     protected void UpdateListView()
     {
+        if (this.UILoaded == false)
+            return;
+
         List<PrefabLightmapDataItem> items = this.FindPrefabLightmapItems();
 
         if (items.Count > 0)
@@ -723,7 +725,6 @@ public class PrefabLightmapTool : EditorWindow
     {
         if (texture == null) return null;
 
-        string scenePath = SceneManager.GetActiveScene().path.Substring(0, SceneManager.GetActiveScene().path.Length - 6);
         string prefabPath = Path.Combine(exportRoot, objectName, lightmapName);
         string assetPath = AssetDatabase.GetAssetPath(texture);
         string newAssetPath = Path.Combine(prefabPath, new FileInfo(assetPath).Name);
@@ -741,6 +742,7 @@ public class PrefabLightmapTool : EditorWindow
             importer.filterMode = FilterMode.Bilinear;
             importer.anisoLevel = 3;
             importer.maxTextureSize = 4096;
+            importer.isReadable = true;
         }
 
         AssetDatabase.ImportAsset(newAssetPath, ImportAssetOptions.ForceUpdate);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added the isReadable flag to the exported textures so that they could be ready by the system when applying textures to the Lightmap Settings.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue, asset and/or documentation issues here: -->
#30 Exported Lightmap Can Not Be Read 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Critical bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed the bug steps and no longer was receiving the notices.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the game logic.
    - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
