### PR TITLE
#36 Moved toggle setter below callback definitions

### DIFF
--- a/Editor/PrefabLightmapTool.cs
+++ b/Editor/PrefabLightmapTool.cs
@@ -152,9 +152,6 @@ public class PrefabLightmapTool : EditorWindow
         this.ButtonClear.SetEnabled(false);
         this.ButtonBake.SetEnabled(false);
 
-        this.TextFieldPath.value = this.LastTextPath;
-        this.ToggleDefault.value = this.LastDefault;
-
         this.TextFieldPath.RegisterValueChangedCallback(this.TextPathChangedEventHandler);
         this.ButtonPath.clicked += this.ButtonPathClicked;
         this.TextFieldName.RegisterValueChangedCallback(this.TextNameChangedEventHandler);
@@ -163,6 +160,9 @@ public class PrefabLightmapTool : EditorWindow
         this.ToggleAll.RegisterValueChangedCallback(this.ToggleAllChangedEventHandler);
         this.ButtonClear.clicked += this.ButtonClearClicked;
         this.ButtonBake.clicked += this.ButtonBakeClicked;
+
+        this.TextFieldPath.value = this.LastTextPath;
+        this.ToggleDefault.value = this.LastDefault;
 
         this.UpdateListView();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The toggle value set was before the callback definitions so that value change call back was not being invoked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue, asset and/or documentation issues here: -->
#36 Slot Name TextInput Not Honoring Serialized Default Toggle

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not exceptions!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed reproduction steps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the game logic.
    - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
