### PR TITLE
#40 Added view null check

### DIFF
--- a/Editor/PrefabLightmapTool.cs
+++ b/Editor/PrefabLightmapTool.cs
@@ -50,10 +50,6 @@ public class PrefabLightmapTool : EditorWindow
     /// Internal value for determining if the bake was started as a result of this tool
     /// </summary>
     protected bool StartedBaking;
-    /// <summary>
-    /// If the GUI has been loaded by CreateGUI
-    /// </summary>
-    protected bool UILoaded;
 
     /// <summary>
     /// Export path text field
@@ -165,8 +161,6 @@ public class PrefabLightmapTool : EditorWindow
         this.ToggleDefault.value = this.LastDefault;
 
         this.UpdateListView();
-
-        this.UILoaded = true;
     }
     public void OnFocus()
     {
@@ -325,7 +319,7 @@ public class PrefabLightmapTool : EditorWindow
     /// </summary>
     protected void UpdateListView()
     {
-        if (this.UILoaded == false)
+        if (this.ListViewBehaviours == null)
             return;
 
         List<PrefabLightmapDataItem> items = this.FindPrefabLightmapItems();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The tool was throwing an exception when the game play mode was entered or exited due to the visual elements not being assigned; though ostensibly the CreateUI member was called. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue, asset and/or documentation issues here: -->
#40 UI Throws Exception on Game Play Start 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No exceptions!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed bug replication instructions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the game logic.
    - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
