### PR TITLE
#42 Added isolated baking

### DIFF
--- a/Editor/UXML/PrefabLightmapTool.uxml
+++ b/Editor/UXML/PrefabLightmapTool.uxml
@@ -16,5 +16,6 @@
         <ui:VisualElement style="flex-direction: row; flex-shrink: 0; flex-grow: 1;" />
         <ui:Button text="Clear" display-tooltip-when-elided="true" name="ButtonClear" enable-rich-text="false" focusable="false" tooltip="Clear the selected PrefabLightmaps" />
         <ui:Button text="Bake" display-tooltip-when-elided="true" name="ButtonBake" enable-rich-text="false" focusable="false" tooltip="Bake the selected PrefabLightmaps" />
+        <ui:Button text="Cancel" display-tooltip-when-elided="true" name="ButtonCancel" tooltip="Cancel the current bake" focusable="false" enable-rich-text="false" style="display: none;" />
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the ability to bake objects in isolation so that the created images were not expanded due to other objects in the scene being simultaneously baked.   Due to this a cancel feature needed to be added so that the array of baked objects would be stopped.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue, asset and/or documentation issues here: -->
#42 Bake GameObjects in Isolation 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When doing multi-object baking, sometimes the created lightmaps would be made larger to accommodate smaller objects and push the resulting image to the maximum dimension, however, this is not ideal when baking for stand-alone objects as it adds unnecessary size and unrelated content to those image.   This aims to reduce the file sizes and/or number and only have those objecting being baked a part of the resulting lightmap data. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have been using it for the past few days to re-bake multiple objects and so far it's been working well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the game logic.
    - [ ] I have linked the project issue above.
- [ ] My change requires a change to the assets.
    - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
    - [ ] I have linked the documentation issue above.
